### PR TITLE
Seems to work now

### DIFF
--- a/clients/lsp-openscad.el
+++ b/clients/lsp-openscad.el
@@ -40,14 +40,14 @@
 
 (defun lsp-openscad-server-start-fun (port)
   `(,lsp-openscad-server-path
-    "--lsp-listen",(number-to-string port)))
+    "--lsp-listen" ,(number-to-string port)))
 
 (defun lsp-openscad-server-connection ()
   (lsp-tcp-connection 'lsp-openscad-server-start-fun))
 
 (lsp-register-client
  (make-lsp-client :new-connection (lsp-openscad-server-connection)
-                  :major-modes '(SCAD/*l)
+                  :major-modes '(scad-mode)
                   :priority -1
                   :server-id 'openscad))
 

--- a/lsp-mode.el
+++ b/lsp-mode.el
@@ -709,6 +709,7 @@ Changes take effect only when a new session is started."
                                         (lua-mode . "lua")
                                         (sass-mode . "sass")
                                         (scss-mode . "scss")
+                                        (scad-mode . "openscad")
                                         (xml-mode . "xml")
                                         (c-mode . "c")
                                         (c++-mode . "cpp")


### PR DESCRIPTION
First, screenshot:
![lsp-openscad](https://user-images.githubusercontent.com/282098/107749789-f98d6700-6d7f-11eb-86e0-2a1a7cadeb54.png)


Currently, when an lsp session in the editor is started, it starts the openscad GUI, but nothing is showing in the window, and the openscad filename says untitled.scad. If I select "preview" in the GUI, nothing happens. How am I to invoke the preview? 

I'm not sure how you envisage the workflow with respect to the GUI though. Would it be a bad thing to allow automatic reload and compile to be enabled, so that preview automatically happens when an explicit file save from the editor occurs? (kind of like my existing workflow)

(If I open a scad file in another project, emacs lsp starts an independent openscad instance on a separate port, which is nice).
